### PR TITLE
Mention that Fossil must be built with the JSON API enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Download it from [github](https://github.com/rguiscard/fossil-notebook-demo/rele
 
 #### Installation ####
 
-[Install fossil](https://fossil-scm.org/home/doc/trunk/www/build.wiki), better to compile with `--with-th1-docs`.
+[Install fossil](https://fossil-scm.org/home/doc/trunk/www/build.wiki): compile with `--enable-json` (mandatory) and `--with-th1-docs` (recommended).
 
 #### Run ####
 


### PR DESCRIPTION
Hi,  
Fossil JSON API is mentioned in the README but not in the "Installation" section, and Fossil `./configure` does not enable the JSON API by default.
It seems worth mentioning it, esp. because without it, the notebook does not display anything, not even an error message: the problem only shows up in the JS console (404 returned to XHR GET requests on /json/).